### PR TITLE
Publishing to pypi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,6 @@ jobs:
 
       - uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
 
       - name: Build package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,17 +34,15 @@ jobs:
           CI: 1
         run: pytest tests
 
-# Comment in when repository is public.
-#      - uses: codecov/codecov-action@v3
-#        with:
-#          file: ./coverage.xml
+      - uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
 
       - name: Build package
         run: poetry build
 
-# Comment in when ready.
-#      - name: Release to PyPI
-#        env:
-#          TWINE_USERNAME: __token__
-#          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-#        run: twine upload --verbose dist/* || echo 'Version exists'
+      - name: Release to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload --verbose dist/* || echo 'Version exists'


### PR DESCRIPTION
## Description
Added steps for publishing to PyPI. ~~Do not merge until secret for PyPI token is available~~

Ready to merge, secret is there.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated. Documentation is generated from docstrings - these must be updated according to your change.
  If a new method has been added it should be referenced in [cognite.rst](https://github.com/cognitedata/cognite-sdk-python/blob/master/docs/source/cognite.rst) in order to generate docs based on its docstring.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [_version.py](https://github.com/cognitedata/cognite-sdk-python/blob/master/cognite/client/_version.py) and [pyproject.toml](https://github.com/cognitedata/cognite-sdk-python/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
