### PR TITLE
restore mypy to examples

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,6 @@ repos:
     rev: v1.1.1
     hooks:
       - id: mypy
-        exclude: "examples/"
         additional_dependencies:
           - types-PyYAML
           - types-requests
@@ -93,3 +92,4 @@ repos:
           - cachelib
           - pytest
         language_version: python3.10
+        entry: bash -c 'MYPYPATH=.:examples mypy "$@"' --

--- a/examples/cinematography_domain/usage.py
+++ b/examples/cinematography_domain/usage.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import logging
 from typing import List, cast
 
+from cinematography_domain.client import CineClient, get_cine_client
+from cinematography_domain.schema import Movie, Person
 from cognite.dm_clients.custom_types import JSONObject, Timestamp
-from examples.cinematography_domain.client import CineClient, get_cine_client
-from examples.cinematography_domain.schema import Movie, Person
 
 
 def _delete_data(client: CineClient) -> None:
@@ -20,13 +20,13 @@ def _upload_data(client: CineClient) -> None:
         Movie(
             externalId="movie1",
             title="Casablanca",
-            release="1942-11-26T11:12:13Z",
+            release="1942-11-26T11:12:13Z",  # type: ignore[arg-type]
             director=Person(externalId="person1", name="Michael Curtiz"),
             actors=[
                 Person(externalId="person2", name="Humphrey Bogart"),
                 Person(externalId="person3", name="Ingrid Bergman"),
             ],
-            meta={"run_time": 102},
+            meta={"run_time": 102},  # type: ignore[arg-type]
         ),
         Movie(
             externalId="movie2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ multi_line_output=3            # corresponds to -m  flag
 include_trailing_comma=true    # corresponds to -tc flag
 skip_glob = '^((?!py$).)*$'    # this makes sort all Python files
 known_third_party = []
+src_paths = [".", "examples"]
 
 [tool.poetry.scripts]
 pygen = "cognite.gqlpygen.main:main"

--- a/tests/test_gqlpygen/test_generation.py
+++ b/tests/test_gqlpygen/test_generation.py
@@ -1,8 +1,8 @@
 import pytest
 
+from cinematography_domain.schema import cine_schema
 from cognite.dm_clients.domain_modeling import DomainModel, Schema
 from cognite.gqlpygen.generator import to_client_sdk
-from examples.cinematography_domain.schema import cine_schema
 from tests.constants import CINEMATOGRAPHY
 
 


### PR DESCRIPTION
`examples` was not meant to be a python package, but just a holder for other packages. This changes the imports accordingly. Configures isort as well and restores mypy coverage.