### PR TITLE
References

### DIFF
--- a/cognite/dm_clients/domain_modeling/domain_model.py
+++ b/cognite/dm_clients/domain_modeling/domain_model.py
@@ -4,7 +4,8 @@ import logging
 from typing import Dict, Optional, Type, get_args
 
 import strawberry
-from pydantic import Extra
+from pydantic import Extra, root_validator, PrivateAttr
+from typing_extensions import Self
 
 from cognite.dm_clients.cdf.data_classes_dm_v3 import DataModelBase
 
@@ -27,13 +28,26 @@ class DomainModel(DataModelBase):
     """
 
     externalId: strawberry.Private[Optional[str]] = None
-    # Private ^ means the field will not be exposed in GraphQL schema
-    # Used here because actual objects (returned from the API) have these fields. These are "implicit" field.
+    _reference: strawberry.Private[bool] = PrivateAttr(False)
+    # strawberry.Private ^ means the field will not be exposed in GraphQL schema
+    # Used on externalID because actual objects (returned from the API) have these fields. These are "implicit" field.
+    # PrivateAttr is telling pydantic to allow the use of this as a regular (non-pydantic) attribute.
 
     class Config:
         extra = Extra.forbid
         #  ^ raises exception if extra fields are passed to the constructor. Very useful for development.
         arbitrary_types_allowed = True
+
+    def __init__(self, *args, _reference: bool = False, **kwargs):
+        if _reference:
+            for field_name, field in self.__fields__.items():
+                if field.required and field_name not in kwargs:
+                    kwargs[field_name] = field.type_()
+        super().__init__(*args, **kwargs)
+        self._reference = _reference
+
+    def as_reference(self) -> Self:
+        return type(self)(externalId=self.externalId, _reference=True)
 
     @classmethod
     def get_one_to_many_attrs(cls) -> Dict[str, Type[DomainModel]]:

--- a/cognite/dm_clients/domain_modeling/relationship_api.py
+++ b/cognite/dm_clients/domain_modeling/relationship_api.py
@@ -36,9 +36,27 @@ class RelationshipAPI:
         self.schema_version = schema_version
         self.space_id = space_id
 
+    def add(self, attribute: str, start_ext_id: str, end_ext_ids: Iterable[str]) -> None:
+        """
+        Create one or more Edge instances on a particular attribute of the `self.model_type` type of instance.
+        """
+        edge_type_ext_id = f"{self.model_type.__name__}.{attribute}"
+        edges = [
+            Edge(
+                externalId=f"{start_ext_id}.{attribute}__{end_ext_id}",
+                space=self.space_id,
+                version=str(self.schema_version),
+                type=RelationReference(space=self.space_id, externalId=edge_type_ext_id),
+                startNode=RelationReference(space=self.space_id, externalId=start_ext_id),
+                endNode=RelationReference(space=self.space_id, externalId=end_ext_id),
+            )
+            for end_ext_id in end_ext_ids
+        ]
+        self.edges_api.apply(edges)
+
     def apply(self, attribute: str, start_ext_id: str, end_ext_ids: Iterable[str]) -> None:
         """
-        Crete an Edge on a particular attribute of the `self.model_type` type of instance.
+        Crete one or more Edge instances on a particular attribute of the `self.model_type` type of instance.
         Additionally:
          * delete obsolete edges
          * don't create duplicate edges (if some exist from before)

--- a/examples/cinematography_domain/usage.py
+++ b/examples/cinematography_domain/usage.py
@@ -66,6 +66,10 @@ def _upload_data(client: CineClient) -> None:
     )
     client.movie.apply([ragnarok])
 
+    # add a relationship knowing only external_id values (first create another actor):
+    client.person.apply([Person(externalId="person10", name="Tessa Thompson")])
+    client.movie.relationships.add("actors", "movie3", ["person10"])
+
 
 def _main() -> None:
     logging.basicConfig()

--- a/examples/cinematography_domain/usage.py
+++ b/examples/cinematography_domain/usage.py
@@ -9,6 +9,7 @@ from cognite.dm_clients.custom_types import JSONObject, Timestamp
 
 
 def _delete_data(client: CineClient) -> None:
+    print("Deleting Movie and Person data.")
     client.person.delete(client.person.list(resolve_relationships=False))
     client.movie.delete(client.movie.list(resolve_relationships=False))
 
@@ -30,18 +31,40 @@ def _upload_data(client: CineClient) -> None:
         ),
         Movie(
             externalId="movie2",
-            title="Star Wars: Episode IV – A New Hope",
-            release=Timestamp("1977-05-25T00:00:00-06"),
-            director=Person(externalId="person4", name="George Lucas"),
+            title="Thor",
+            release=Timestamp("2011-04-17T00:00:00+10"),
+            director=Person(externalId="person4", name="Kenneth Branagh"),
             actors=[
-                Person(externalId="person5", name="Mark Hamill"),
-                Person(externalId="person6", name="Harrison Ford"),
-                Person(externalId="person7", name="Carrie Fisher"),
+                Person(externalId="person5", name="Chris Hemsworth"),
+                Person(externalId="person6", name="Natalie Portman"),
+                Person(externalId="person7", name="Tom Hiddleston"),
             ],
-            meta=JSONObject({"run_time": 121}),
+            meta=JSONObject({"run_time": 114}),
         ),
     ]
     client.movie.apply(movies)
+
+    # add another movie, showing the use of _reference
+    ragnarok = Movie(
+        externalId="movie3",
+        title="Thor: Ragnarok",
+        release=Timestamp("2017-10-10T00:00:00-08"),
+        director=Person(externalId="person8", name="Taika Waititi"),
+        actors=[
+            # These persons already exist. We need not fill all fields
+            # only externalId and set _reference=True.
+            # Note: we could instead fill all fields instead (just "name" in
+            # this example), and the API would update the fields. By using
+            # _reference=True, we don't update those field, only create the relations
+            Person(externalId="person5", _reference=True),
+            Person(externalId="person7", _reference=True),
+
+            Person(externalId="person9", name="Cate Blanchett"),
+
+        ],
+        meta=JSONObject({"run_time": 130}),
+    )
+    client.movie.apply([ragnarok])
 
 
 def _main() -> None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1694,4 +1694,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "0954bdafa8a99260f459910ac4597bde0382f5d774cdbe1ed2910f37bcf5cbf0"
+content-hash = "b0f5345ea4f293ae7e05c91de686fdaf52f0e7e5e348ac9ec1a2d6c21c13fabd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dynaconf = "^3.1.12"
 graphql-core = ">=3.2"
 Jinja2 = ">=3.1"
 packaging = "^23.1"
+typing-extensions = "^4.5.0"
 
 [tool.poetry.dev-dependencies]
 twine = "*"


### PR DESCRIPTION
## Description

Two things in this PR:
 1. Instantiate an item (i.e. an instance of `Movie`, `Actor`, etc.) using only externalId, as a reference.
 2. Creating a relationship (i.e. an `Edge` instance) without loading any items (i.e. just knowing external IDs).

Both of these additions serve to avoid the need to load many items when doing a simple operation.

#### Example:

Data model: `Genre  --.movies-->  Movie  --.actors-->  Actor`

Assume we wanted to add a movie to a genre. 

##### 1. Already having the `Movie` loaded

```
>>> the_genre.movies.append(the_movie.as_reference()) 
>>> client.genre.apply([the_genre])
```

Using `.as_reference()` will avoid any API calls that would update fields on the movie, and subsequently update actors as well. Since there can be many actors in a movie, this can save a lot of wasted API calls.

It will still run through all the movies, so it is useful when uploading multiple data items and wanting to optimise API calls.


##### 2. Only create the relationship

```
>>> client.genre.relationships.add("actors", "ID_for_the_movie", ["ID_for_the_actor"])
```

This only creates the `Edge` without anything else.


## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-gql-pygen/blob/main/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in
  [version.py](https://github.com/cognitedata/cognite-gql-pygen/blob/main/cognite/gqlpygen/version.py) and
  [pyproject.toml](https://github.com/cognitedata/cognite-gql-pygen/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
